### PR TITLE
Detect and extract application/x-gzip content type

### DIFF
--- a/pkg/backend/server.go
+++ b/pkg/backend/server.go
@@ -557,7 +557,7 @@ func (c *app) uploadLogs(w http.ResponseWriter, r *http.Request) {
     })
 
     mime := handler.Header.Get("Content-Type")
-    if mime == "application/gzip" {
+    if mime == "application/gzip" || mime == "application/x-gzip" {
         if err := handleTarGz(destinationFilePath, "/space"); err != nil {
             http.Error(w, err.Error(), http.StatusInternalServerError)
             return


### PR DESCRIPTION
On my tests, RHEL 8 gzip by default creates x-gzip (tar -j or gzip). Detect also application/x-gzip and extract it.