### PR TITLE
A few fixes for older mustgather imports

### DIFF
--- a/frontend/src/app/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/Dashboard/Dashboard.tsx
@@ -463,7 +463,8 @@ const Dashboard: React.FunctionComponent = () => {
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {importedMustGathers.data.map((mustGather) => (
+                  {importedMustGathers.data.map((mustGather) => {
+                      return (
                     <Tr
                       key={mustGather.name}
                       onRowClick={() => setMustGatherInsightData(mustGather.insightsData)}
@@ -474,13 +475,13 @@ const Dashboard: React.FunctionComponent = () => {
                       <Td dataLabel={columnNames.gatherTime}>{new Date(mustGather.gatherTime).toLocaleString()}</Td>
                       <Td dataLabel={columnNames.importTime}>{new Date(mustGather.importTime).toLocaleString()}</Td>
                       <Td dataLabel={columnNames.insightsData}>{
-                          mustGather.insightsData === undefined || mustGather.insightsData === null ?
+                          mustGather.insightsData === undefined || mustGather.insightsData === null || mustGather.insightsData === "" ?
                             <span>-</span>
                           :
                             insightsIcons(mustGather.insightsData)
                       }</Td>
                     </Tr>
-                  ))}
+                  )})}
                 </Tbody>
               </Table>
             )

--- a/pkg/backend/logsHandler.go
+++ b/pkg/backend/logsHandler.go
@@ -401,10 +401,17 @@ func getMustGatherTimestamp() (time.Time, error) {
 
 func timestampStringToTime(timestamp string) (time.Time, error) {
 	const layout = "2006-01-02 15:04:05.999999999 -0700 MST m=+0.000000000"
+	const layoutNoMono = "2006-01-02 15:04:05.999999999 -0700 MST"
 
 	t, err := time.Parse(layout, timestamp)
 	if err != nil {
-		return time.Time{}, err
+        // remove the monolithic offset if we can't parse it
+        parts := strings.Split(timestamp, " m=")
+        
+        t, err = time.Parse(layoutNoMono, parts[0])
+        if err != nil {
+            return time.Time{}, err
+        }
 	}
 
 	return t, nil

--- a/pkg/backend/server.go
+++ b/pkg/backend/server.go
@@ -932,7 +932,7 @@ func (c *app) uploadLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mime := handler.Header.Get("Content-Type")
-	if mime == "application/gzip" || mime == "application/x-gzip" {
+	if mime == "application/gzip" || mime == "application/x-gzip" || mime == "application/x-compressed-tar" {
 		if err := handleTarGz(destinationFilePath, "/space"); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
This PR fixes two issues that arise when importing an older mustgather.
 - It's difficult to accurately parse the monotonic clock, try without it if it fails.
 - Not all must gathers have insight data, some times it can appear as an empty string. 